### PR TITLE
[SETL-7] Review ExcelConnector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>com.crealytics</groupId>
             <artifactId>spark-excel_${scala.compat.version}</artifactId>
-            <version>0.12.2</version>
+            <version>0.12.4</version>
         </dependency>
         <dependency>
             <groupId>com.audienceproject</groupId>

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
@@ -152,7 +152,7 @@ class ExcelConnector(val path: String,
       case SaveMode.Append =>
         /*
          If write mode is set to Append:
-           - when the file doesn't contains the current sheet, a new sheet will be created in the file and data
+           - when the file doesn't contain the current sheet, a new sheet will be created in the file and data
              will be written
            - when the file already contains the current sheet, then this sheet will be overwritten
          */

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/ExcelConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/ExcelConnectorSuite.scala
@@ -186,7 +186,15 @@ class ExcelConnectorSuite extends AnyFunSuite with Matchers {
     deleteRecursively(new File("src/test/resources/test_excel_sheet.xlsx"))
   }
 
-  test("ExeclConnector with multiple sheets") {
+  test("ExcelConnector with multiple sheets") {
+    /*
+    We test the ExcelConnector by creating a file with multiple sheets with different save mode.
+
+    If write mode is set to Append:
+      - when the file doesn't contains the current sheet, a new sheet will be created in the file and data
+        will be written
+      - when the file already contains the current sheet, then this sheet will be overwritten
+     */
     val spark: SparkSession = SparkSession.builder().config(new SparkConf()).master("local[*]").getOrCreate()
     import spark.implicits._
 

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/ExcelConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/ExcelConnectorSuite.scala
@@ -163,6 +163,12 @@ class ExcelConnectorSuite extends AnyFunSuite with Matchers {
   test("ExcelConnector's sheetName option doesn't work") {
     val spark: SparkSession = SparkSession.builder().config(new SparkConf()).master("local[*]").getOrCreate()
     import spark.implicits._
+    val logger = Logger.getLogger(classOf[ExcelConnector])
+    val outContent = new ByteArrayOutputStream()
+    val appender = new WriterAppender(new SimpleLayout, outContent)
+    logger.addAppender(appender)
+    val warnMessage = "The option `sheetName` is ignored. Use dataAddress"
+    
     val conf = new Conf()
       .set("path", "src/test/resources/test_excel_sheet.xlsx")
       .set("sheetName", "testSheet")
@@ -171,6 +177,7 @@ class ExcelConnectorSuite extends AnyFunSuite with Matchers {
       .set("saveMode", "Overwrite")
 
     val connector = new ExcelConnector(conf)
+    assert(outContent.toString.contains(warnMessage))
     connector.write(testTable.toDF)
 
     assertThrows[IllegalArgumentException](

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/ExcelConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/ExcelConnectorSuite.scala
@@ -11,8 +11,9 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Dataset, SaveMode, SparkSession}
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ExcelConnectorSuite extends AnyFunSuite {
+class ExcelConnectorSuite extends AnyFunSuite with Matchers {
 
   import SparkRepositorySuite.deleteRecursively
 
@@ -157,5 +158,125 @@ class ExcelConnectorSuite extends AnyFunSuite {
     assertThrows[IllegalArgumentException](connector.write(testTable.toDF()))
 
     deleteRecursively(new File(path))
+  }
+
+  test("ExcelConnector's sheetName option doesn't work") {
+    val spark: SparkSession = SparkSession.builder().config(new SparkConf()).master("local[*]").getOrCreate()
+    import spark.implicits._
+    val conf = new Conf()
+      .set("path", "src/test/resources/test_excel_sheet.xlsx")
+      .set("sheetName", "testSheet")
+      .set("useHeader", "true")
+      .set("inferSchema", "true")
+      .set("saveMode", "Overwrite")
+
+    val connector = new ExcelConnector(conf)
+    connector.write(testTable.toDF)
+
+    assertThrows[IllegalArgumentException](
+      spark.read
+        .format("com.crealytics.spark.excel")
+        .option("dataAddress", "testSheet!A1")
+        .option("useHeader", "true")
+        .option("inferSchema", "true")
+        .load("src/test/resources/test_excel_sheet.xlsx")
+        .show()
+    )
+
+    deleteRecursively(new File("src/test/resources/test_excel_sheet.xlsx"))
+  }
+
+  test("ExeclConnector with multiple sheets") {
+    val spark: SparkSession = SparkSession.builder().config(new SparkConf()).master("local[*]").getOrCreate()
+    import spark.implicits._
+
+    val thisPath = "src/test/resources/test_excel_with_multiple_sheets.xlsx"
+
+    // create new file and save to testSheet
+    val conf1 = new Conf()
+      .set("path", thisPath)
+      .set("dataAddress", "testSheet!A1")
+      .set("useHeader", "true")
+      .set("inferSchema", "true")
+      .set("saveMode", "Overwrite")
+
+    // append testSheet2 to file
+    val conf2 = new Conf()
+      .set("path", thisPath)
+      .set("dataAddress", "testSheet2!A1")
+      .set("useHeader", "true")
+      .set("inferSchema", "true")
+      .set("saveMode", "Append")
+
+
+    val testTable1: Dataset[TestObject] = Seq(
+      TestObject(1, "p1", "c1", 1L),
+      TestObject(1, "p1", "c1", 1L)
+    ).toDS()
+
+    val testTable2: Dataset[TestObject] = Seq(
+      TestObject(3, "p3", "c3", 3L)
+    ).toDS()
+
+    val connector1 = new ExcelConnector(conf1)
+    val connector2 = new ExcelConnector(conf2)
+
+    connector1.write(testTable1.toDF())
+    connector2.write(testTable2.toDF())
+
+    // create file
+    assert(connector1.read().count() === 2)
+    connector1.read()
+        .select(
+          $"partition1".cast(IntegerType).as[Int],
+          $"partition2".as[String],
+          $"clustering1".as[String],
+          $"value".cast(LongType).as[Long]
+        )
+        .as[TestObject]
+        .collect() should contain theSameElementsAs testTable1.collect()
+
+    // add data to testSheet2
+    assert(connector2.read().count() === 1)
+    connector2.read()
+      .select(
+        $"partition1".cast(IntegerType).as[Int],
+        $"partition2".as[String],
+        $"clustering1".as[String],
+        $"value".cast(LongType).as[Long]
+      )
+      .as[TestObject]
+      .collect() should contain theSameElementsAs testTable2.collect()
+
+    // Append to an existing testSheet2 should overwrite it
+    connector2.write(testTable1.toDF())
+    assert(connector2.read().count() === 2)
+    connector2.read()
+      .select(
+        $"partition1".cast(IntegerType).as[Int],
+        $"partition2".as[String],
+        $"clustering1".as[String],
+        $"value".cast(LongType).as[Long]
+      )
+      .as[TestObject]
+      .collect() should contain theSameElementsAs testTable1.collect()
+
+    // Overwrite the whole file
+    connector1.write(testTable2.toDF())
+    assert(connector1.read().count() === 1)
+    connector1.read()
+      .select(
+        $"partition1".cast(IntegerType).as[Int],
+        $"partition2".as[String],
+        $"clustering1".as[String],
+        $"value".cast(LongType).as[Long]
+      )
+      .as[TestObject]
+      .collect() should contain theSameElementsAs testTable2.collect()
+
+    // testSheet2 is gone
+    assertThrows[IllegalArgumentException](connector2.read().show())
+
+    deleteRecursively(new File(thisPath))
   }
 }


### PR DESCRIPTION
**Changes**
1. Enhance unit test:
  We test the ExcelConnector by creating a file with multiple sheets with different save mode.
  If write mode is set to Append:
    - when the file doesn't contains the current sheet, a new sheet will be created in the file and data
       will be written
    - when the file already contains the current sheet, then this sheet will be overwritten
2. The option `sheetName` is ignored in the library **spark-excel_2.11**. I think it's an issue. A warning is logged if the user defines this option in the constructor

**Commit log**
chore: enhance unit test of excel connector
chore: upgrade spark-excel connector

Signed-off-by: Xuzhou Qin <xuzhou.qin@jcdecaux.com>