### PR TITLE
[SETL-88] Change benchmark unit of time from nanoseconds to seconds

### DIFF
--- a/src/main/java/com/jcdecaux/setl/internal/BenchmarkInvocationHandler.java
+++ b/src/main/java/com/jcdecaux/setl/internal/BenchmarkInvocationHandler.java
@@ -19,7 +19,7 @@ public class BenchmarkInvocationHandler implements InvocationHandler {
 
     private final Map<String, Method> methods = new HashMap<>();
 
-    private Map<String, Long> benchmarkResult = new HashMap<>();
+    private Map<String, Double> benchmarkResult = new HashMap<>();
 
     private static Logger logger = LogManager.getLogger(BenchmarkInvocationHandler.class);
 
@@ -33,7 +33,7 @@ public class BenchmarkInvocationHandler implements InvocationHandler {
         }
     }
 
-    public Map<String, Long> getBenchmarkResult() {
+    public Map<String, Double> getBenchmarkResult() {
         return benchmarkResult;
     }
 
@@ -48,11 +48,12 @@ public class BenchmarkInvocationHandler implements InvocationHandler {
             long start = System.nanoTime();
             result = targetMethod.invoke(target, args);
             long elapsed = System.nanoTime() - start;
+            double seconds = (double)elapsed / 1_000_000_000.0;
 
-            this.benchmarkResult.put(targetMethod.getName(), elapsed);
+            this.benchmarkResult.put(targetMethod.getName(), seconds);
 
             logger.info("Executing " + target.getClass().getSimpleName() + "." +
-                    method.getName() + " finished in " + elapsed + " ns");
+                    method.getName() + " finished in " + seconds + " s");
         } else {
             // if the method doesn't have the Benchmark annotation, run it without measuring the elapsed time
             result = targetMethod.invoke(target, args);

--- a/src/main/scala/com/jcdecaux/setl/BenchmarkResult.scala
+++ b/src/main/scala/com/jcdecaux/setl/BenchmarkResult.scala
@@ -1,16 +1,16 @@
 package com.jcdecaux.setl
 
-case class BenchmarkResult(cls: String, read: Long, process: Long, write: Long, get: Long, total: Long) {
+case class BenchmarkResult(cls: String, read: Double, process: Double, write: Double, get: Double, total: Double) {
 
   override def toString: String = {
 
     val formatter = java.text.NumberFormat.getNumberInstance
 
     s"Benchmark class: $cls\n" +
-      s"Total elapsed time: ${formatter.format(total)} ns\n" +
-      s"read: ${formatter.format(read)} ns\n" +
-      s"process: ${formatter.format(process)} ns\n" +
-      s"write: ${formatter.format(write)} ns\n" +
+      s"Total elapsed time: ${formatter.format(total)} s\n" +
+      s"read: ${formatter.format(read)} s\n" +
+      s"process: ${formatter.format(process)} s\n" +
+      s"write: ${formatter.format(write)} s\n" +
       "================="
   }
 

--- a/src/main/scala/com/jcdecaux/setl/workflow/Stage.scala
+++ b/src/main/scala/com/jcdecaux/setl/workflow/Stage.scala
@@ -213,17 +213,17 @@ class Stage extends Logging
       proxyFactory.write()
     }
 
-    val elapsed = System.nanoTime() - start
-    log.info(s"Execution of $factoryName finished in $elapsed ns")
+    val elapsed = (System.nanoTime() - start) / 1000000000.0
+    log.info(s"Execution of $factoryName finished in $elapsed s")
 
     val result = benchmarkInvocationHandler.getBenchmarkResult
 
     BenchmarkResult(
       factory.getClass.getSimpleName,
-      result.getOrDefault("read", 0L),
-      result.getOrDefault("process", 0L),
-      result.getOrDefault("write", 0L),
-      result.getOrDefault("get", 0L),
+      result.getOrDefault("read", 0.0),
+      result.getOrDefault("process", 0.0),
+      result.getOrDefault("write", 0.0),
+      result.getOrDefault("get", 0.0),
       elapsed
     )
   }


### PR DESCRIPTION
Because of the ```formatter``` in ```BenchmarkResult.scala```, the output of ```getBenchmarkResult``` can be:
```
Benchmark class: BenchmarkFactory
Total elapsed time: 1,002 s
read: 0 s
process: 0 s
write: 1,001 s
```
while the info log is:
```
2020-01-29 11:48:55 INFO  setl.internal.BenchmarkInvocationHandler:55 - Executing BenchmarkFactory.process finished in 5.0E-6 s
2020-01-29 11:48:56 INFO  setl.internal.BenchmarkInvocationHandler:55 - Executing BenchmarkFactory.write finished in 1.0010407 s
2020-01-29 11:48:56 INFO  setl.workflow.Stage:217 - Execution of BenchmarkFactory finished in 1.0017971 s
```

Do we want the current time format or do we prefer the time format of the info log ?