### PR TITLE
[SETL-83] Add drop method in DBConnector

### DIFF
--- a/src/main/scala/com/jcdecaux/setl/config/JDBCConnectorConf.scala
+++ b/src/main/scala/com/jcdecaux/setl/config/JDBCConnectorConf.scala
@@ -1,7 +1,7 @@
 package com.jcdecaux.setl.config
 
 import org.apache.spark.sql.SaveMode
-import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
+import org.apache.spark.sql.execution.datasources.jdbc.JDBCOptions
 
 class JDBCConnectorConf extends ConnectorConf {
 
@@ -67,6 +67,20 @@ class JDBCConnectorConf extends ConnectorConf {
   override def getWriterConf: Map[String, String] = {
     import scala.collection.JavaConverters._
     settings.asScala.toMap - FETCH_SIZE - FORMAT - SAVEMODE - PARTITION_COLUMN - LOWER_BOUND - UPPER_BOUND
+  }
+
+  @throws[java.lang.IllegalArgumentException]
+  def getJDBCOptions: JDBCOptions = {
+    val parameters: Map[String, String] = Array(
+      JDBCConnectorConf.USER,
+      JDBCConnectorConf.PASSWORD,
+      JDBCConnectorConf.URL,
+      JDBCConnectorConf.DB_TABLE
+    ).collect {
+      case key: String if this.has(key) => key -> this.get(key).get
+    }.toMap
+
+    new JDBCOptions(parameters)
   }
 
 }

--- a/src/main/scala/com/jcdecaux/setl/config/JDBCConnectorConf.scala
+++ b/src/main/scala/com/jcdecaux/setl/config/JDBCConnectorConf.scala
@@ -1,6 +1,7 @@
 package com.jcdecaux.setl.config
 
 import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.catalyst.util.CaseInsensitiveMap
 
 class JDBCConnectorConf extends ConnectorConf {
 

--- a/src/main/scala/com/jcdecaux/setl/internal/CanCreate.scala
+++ b/src/main/scala/com/jcdecaux/setl/internal/CanCreate.scala
@@ -1,0 +1,11 @@
+package com.jcdecaux.setl.internal
+
+import org.apache.spark.sql.DataFrame
+
+trait CanCreate {
+
+  def create(t: DataFrame, suffix: Option[String]): Unit
+
+  def create(t: DataFrame): Unit
+
+}

--- a/src/main/scala/com/jcdecaux/setl/internal/CanDelete.scala
+++ b/src/main/scala/com/jcdecaux/setl/internal/CanDelete.scala
@@ -1,0 +1,7 @@
+package com.jcdecaux.setl.internal
+
+trait CanDelete {
+
+  def delete(query: String): Unit
+
+}

--- a/src/main/scala/com/jcdecaux/setl/internal/CanDrop.scala
+++ b/src/main/scala/com/jcdecaux/setl/internal/CanDrop.scala
@@ -1,0 +1,7 @@
+package com.jcdecaux.setl.internal
+
+trait CanDrop {
+
+  def drop(): Unit
+
+}

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
@@ -177,6 +177,7 @@ class CassandraConnector(val keyspace: String,
     }
   }
 
+  @throws[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException]("Make sure the strategy is correct")
   def createKeyspace(strategy: String, replicationFactor: Int): Unit = {
     cqlConnection.withSessionDo {
       session =>

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
@@ -1,5 +1,6 @@
 package com.jcdecaux.setl.storage.connector
 
+import com.datastax.spark.connector.cql.{CassandraConnector => DatastaxCassandraConnector}
 import com.datastax.driver.core.exceptions.AlreadyExistsException
 import com.datastax.spark.connector._
 import com.jcdecaux.setl.annotation.InterfaceStability
@@ -75,6 +76,8 @@ class CassandraConnector(val keyspace: String,
    * @param config [[com.typesafe.config.Config]] typesafe Config object
    */
   def this(spark: SparkSession, config: Config) = this(config)
+
+  private[this] val cqlConnection =  DatastaxCassandraConnector(spark.sparkContext.getConf)
 
   override val reader: DataFrameReader = spark.read.cassandraFormat(table, keyspace)
 
@@ -166,4 +169,26 @@ class CassandraConnector(val keyspace: String,
       .where(query)
       .deleteFromCassandra(keyspace, table)
   }
+
+  override def drop(): Unit = {
+    cqlConnection.withSessionDo {
+      session =>
+        session.execute(s"DROP TABLE IF EXISTS $keyspace.$table;")
+    }
+  }
+
+  def createKeyspace(strategy: String, replicationFactor: Int): Unit = {
+    cqlConnection.withSessionDo {
+      session =>
+        session.execute(s"CREATE KEYSPACE IF NOT EXISTS $keyspace WITH replication = {'class':'$strategy', 'replication_factor':$replicationFactor};")
+    }
+  }
+
+  private[this] def dropKeyspace(): Unit = {
+    cqlConnection.withSessionDo {
+      session =>
+        session.execute(s"DROP KEYSPACE IF EXISTS $keyspace;")
+    }
+  }
+
 }

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/Connector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/Connector.scala
@@ -3,6 +3,7 @@ package com.jcdecaux.setl.storage.connector
 import com.jcdecaux.setl.annotation.InterfaceStability
 import com.jcdecaux.setl.enums.Storage
 import com.jcdecaux.setl.internal.Logging
+import com.jcdecaux.setl.util.HasSparkSession
 import org.apache.spark.sql._
 
 /**
@@ -18,35 +19,32 @@ import org.apache.spark.sql._
  *
  */
 @InterfaceStability.Evolving
-trait Connector extends Logging {
-
-  val spark: SparkSession
+trait Connector extends HasSparkSession with Logging {
 
   val storage: Storage
 
-  val reader: DataFrameReader
+  protected val reader: DataFrameReader
 
-  val writer: DataFrame => DataFrameWriter[Row]
+  protected val writer: DataFrame => DataFrameWriter[Row]
 
   def read(): DataFrame
 
-  @deprecated("This method will be removed in v0.4. Use `write(t: DataFrame)` instead.", "0.3.0")
   def write(t: DataFrame, suffix: Option[String]): Unit
 
   def write(t: DataFrame): Unit
+
 }
 
 object Connector {
+
   def empty: Connector = new Connector {
     override val spark: SparkSession = null
     override val storage: Storage = null
     override val reader: DataFrameReader = null
     override val writer: DataFrame => DataFrameWriter[Row] = null
-
     override def read(): DataFrame = null
-
     override def write(t: DataFrame, suffix: Option[String]): Unit = {}
-
     override def write(t: DataFrame): Unit = {}
   }
+
 }

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/DBConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/DBConnector.scala
@@ -1,15 +1,12 @@
 package com.jcdecaux.setl.storage.connector
 
 import com.jcdecaux.setl.annotation.InterfaceStability
-import com.jcdecaux.setl.util.HasSparkSession
-import org.apache.spark.sql.DataFrame
+import com.jcdecaux.setl.internal.{CanCreate, CanDelete, CanDrop}
 
 @InterfaceStability.Evolving
-abstract class DBConnector extends Connector with HasSparkSession {
-  @deprecated("This method will be removed in v0.4. Use `create(t: DataFrame)` instead.", "0.3.0")
-  def create(t: DataFrame, suffix: Option[String]): Unit
+abstract class DBConnector extends Connector
+  with CanCreate
+  with CanDrop
+  with CanDelete {
 
-  def create(t: DataFrame): Unit
-
-  def delete(query: String): Unit
 }

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnector.scala
@@ -109,4 +109,9 @@ class DynamoDBConnector(val conf: DynamoDBConnectorConf) extends DBConnector {
   override def write(t: DataFrame): Unit = {
     writeDynamoDB(t, conf.getTable.get)
   }
+
+  override def drop(): Unit = {
+    log.warn("Drop is not supported in DynamoDBConnector")
+  }
+
 }

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
@@ -40,7 +40,7 @@ class ExcelConnector(val path: String,
                      var workbookPassword: Option[String],
                      var schema: Option[StructType],
                      var saveMode: SaveMode
-                    ) extends Connector with HasSparkSession {
+                    ) extends Connector {
 
   // CONSTRUCTORS
   def this(spark: SparkSession,

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/FileConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/FileConnector.scala
@@ -18,7 +18,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.matching.Regex
 
 @InterfaceStability.Evolving
-abstract class FileConnector(val options: FileConnectorConf) extends Connector with HasSparkSession {
+abstract class FileConnector(val options: FileConnectorConf) extends Connector {
 
   def this(options: Map[String, String]) = this(FileConnectorConf.fromMap(options))
 

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
@@ -38,7 +38,7 @@ class JDBCConnector(val conf: JDBCConnectorConf) extends DBConnector {
   @deprecated("use the constructor with no spark session", "0.3.4")
   def this(sparkSession: SparkSession, conf: Conf) = this(conf)
 
-  private[this] val jdbcConnectorOption = {
+  private[this] lazy val jdbcConnectorOption: JDBCOptions = {
     val prop = new java.util.Properties
 
     conf.getUser match {
@@ -52,7 +52,7 @@ class JDBCConnector(val conf: JDBCConnectorConf) extends DBConnector {
     }
 
     conf.getUrl match {
-      case Some(url) =>   prop.setProperty("url", url)
+      case Some(url) => prop.setProperty("url", url)
       case _ =>
     }
 
@@ -64,7 +64,7 @@ class JDBCConnector(val conf: JDBCConnectorConf) extends DBConnector {
     import scala.collection.JavaConverters._
 
     val parameters = prop.asScala.toMap
-    new org.apache.spark.sql.execution.datasources.jdbc.JdbcOptionsInWrite(parameters)
+    new JDBCOptions(parameters)
   }
 
   private[this] def executeRequest(request: String): Unit = {

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
@@ -39,31 +39,15 @@ class JDBCConnector(val conf: JDBCConnectorConf) extends DBConnector {
   def this(sparkSession: SparkSession, conf: Conf) = this(conf)
 
   private[this] lazy val jdbcConnectorOption: JDBCOptions = {
-    val prop = new java.util.Properties
+    val parameters: Map[String, String] = Array(
+      JDBCConnectorConf.USER,
+      JDBCConnectorConf.PASSWORD,
+      JDBCConnectorConf.URL,
+      JDBCConnectorConf.DB_TABLE
+    ).collect {
+      case key: String if conf.has(key) => key -> conf.get(key).get
+    }.toMap
 
-    conf.getUser match {
-      case Some(user) => prop.setProperty("user", user)
-      case _ =>
-    }
-
-    conf.getPassword match {
-      case Some(pw) => prop.setProperty("password", pw)
-      case _ =>
-    }
-
-    conf.getUrl match {
-      case Some(url) => prop.setProperty("url", url)
-      case _ =>
-    }
-
-    conf.getDbTable match {
-      case Some(table) => prop.setProperty("dbtable", table)
-      case _ =>
-    }
-
-    import scala.collection.JavaConverters._
-
-    val parameters = prop.asScala.toMap
     new JDBCOptions(parameters)
   }
 

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/JDBCConnector.scala
@@ -38,21 +38,8 @@ class JDBCConnector(val conf: JDBCConnectorConf) extends DBConnector {
   @deprecated("use the constructor with no spark session", "0.3.4")
   def this(sparkSession: SparkSession, conf: Conf) = this(conf)
 
-  private[this] lazy val jdbcConnectorOption: JDBCOptions = {
-    val parameters: Map[String, String] = Array(
-      JDBCConnectorConf.USER,
-      JDBCConnectorConf.PASSWORD,
-      JDBCConnectorConf.URL,
-      JDBCConnectorConf.DB_TABLE
-    ).collect {
-      case key: String if conf.has(key) => key -> conf.get(key).get
-    }.toMap
-
-    new JDBCOptions(parameters)
-  }
-
   private[this] def executeRequest(request: String): Unit = {
-    val statement = JdbcUtils.createConnectionFactory(jdbcConnectorOption)().createStatement()
+    val statement = JdbcUtils.createConnectionFactory(conf.getJDBCOptions)().createStatement()
     statement.execute(request)
     statement.close()
   }

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/CassandraConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/CassandraConnectorSuite.scala
@@ -237,7 +237,14 @@ class CassandraConnectorSuite extends AnyFunSuite with BeforeAndAfterAll {
 
     // test create keyspace
     this.connector.withSessionDo (_.execute("DROP KEYSPACE IF EXISTS test_spark_connector_keyspace"))
-    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](connector.write(testTable.toDF()))
+    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](
+      connector.write(testTable.toDF()),
+      "Exception should be thrown because the keyspace doesn't exist"
+    )
+    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](
+      connector.createKeyspace("WrongStrategy", 1),
+      "Exception should be thrown when the strategy is wrong"
+    )
     connector.createKeyspace("SimpleStrategy", 1)
     connector.write(testTable.toDF())
     assert(connector.read().count() === 3)
@@ -247,7 +254,10 @@ class CassandraConnectorSuite extends AnyFunSuite with BeforeAndAfterAll {
     val dropMethod = classOf[CassandraConnector].getDeclaredMethod("dropKeyspace")
     dropMethod.setAccessible(true)
     dropMethod.invoke(connector)
-    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](connector.write(testTable.toDF()))
+    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](
+      connector.write(testTable.toDF()),
+      "Exception should be thrown because the keyspace was dropped"
+    )
   }
 
 }

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/CassandraConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/CassandraConnectorSuite.scala
@@ -12,9 +12,7 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class CassandraConnectorSuite extends AnyFunSuite with BeforeAndAfterAll {
 
-
   val connector: CC = CC(MockCassandra.cassandraConf)
-
   val keyspace = "test_space"
 
   override def beforeAll(): Unit = {
@@ -186,4 +184,70 @@ class CassandraConnectorSuite extends AnyFunSuite with BeforeAndAfterAll {
 
     assert(connector.read().count() == connector2.read().count())
   }
+
+  test("CassandraConnector should drop table") {
+    val spark: SparkSession = new SparkSessionBuilder("cassandra")
+      .withSparkConf(MockCassandra.cassandraConf)
+      .setEnv("local")
+      .build().get()
+
+    import spark.implicits._
+
+    val testTable: Dataset[TestObject] = Seq(
+      TestObject(1, "p1", "c1", 1L),
+      TestObject(2, "p2", "c2", 2L),
+      TestObject(3, "p3", "c3", 3L)
+    ).toDS()
+
+    val connector = new CassandraConnector(
+      keyspace = keyspace,
+      table = "test_spark_connector_drop_table",
+      spark = spark,
+      partitionKeyColumns = Some(Seq("partition1", "partition2")),
+      clusteringKeyColumns = Some(Seq("clustering1"))
+    )
+
+    connector.write(testTable.toDF())
+    assert(connector.read().count() === 3)
+    connector.drop()
+    assertThrows[java.io.IOException](connector.read().show())
+  }
+
+  test("CassandraConnector should be able to create and drop keyspace") {
+    val spark: SparkSession = new SparkSessionBuilder("cassandra")
+      .withSparkConf(MockCassandra.cassandraConf)
+      .setEnv("local")
+      .build().get()
+
+    import spark.implicits._
+
+    val testTable: Dataset[TestObject] = Seq(
+      TestObject(1, "p1", "c1", 1L),
+      TestObject(2, "p2", "c2", 2L),
+      TestObject(3, "p3", "c3", 3L)
+    ).toDS()
+
+    val connector = new CassandraConnector(
+      keyspace = "test_spark_connector_keyspace",
+      table = "test_spark_connector_drop_table",
+      spark = spark,
+      partitionKeyColumns = Some(Seq("partition1", "partition2")),
+      clusteringKeyColumns = Some(Seq("clustering1"))
+    )
+
+    // test create keyspace
+    this.connector.withSessionDo (_.execute("DROP KEYSPACE IF EXISTS test_spark_connector_keyspace"))
+    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](connector.write(testTable.toDF()))
+    connector.createKeyspace("SimpleStrategy", 1)
+    connector.write(testTable.toDF())
+    assert(connector.read().count() === 3)
+    assert(connector.read().columns.length === 4)
+
+    // drop the keyspace
+    val dropMethod = classOf[CassandraConnector].getDeclaredMethod("dropKeyspace")
+    dropMethod.setAccessible(true)
+    dropMethod.invoke(connector)
+    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](connector.write(testTable.toDF()))
+  }
+
 }

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/ConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/ConnectorSuite.scala
@@ -14,8 +14,6 @@ class ConnectorSuite extends AnyFunSuite with BeforeAndAfterAll {
 
     assert(Connector.empty.spark === null)
     assert(Connector.empty.storage === null)
-    assert(Connector.empty.reader === null)
-    assert(Connector.empty.writer === null)
     assert(Connector.empty.read() === null)
     Connector.empty.write(df)
     Connector.empty.write(df, Some("suffix"))

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnectorSuite.scala
@@ -181,7 +181,7 @@ class DynamoDBConnectorSuite extends AnyFunSuite with Matchers {
 
     outContent.reset()
     connector.drop()
-    assert(outContent.toString.contain("Drop is not supported in DynamoDBConnector"))
+    assert(outContent.toString.contains("Drop is not supported in DynamoDBConnector"))
   }
 
 }

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnectorSuite.scala
@@ -179,7 +179,9 @@ class DynamoDBConnectorSuite extends AnyFunSuite with Matchers {
     connector.write(data, Some("suffix"))
     assert(outContent.toString.contains("Suffix will be ignored in DynamoDBConnector"))
 
+    outContent.reset()
     connector.drop()
+    assert(outContent.toString.contain("Drop is not supported in DynamoDBConnector"))
   }
 
 }

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/DynamoDBConnectorSuite.scala
@@ -178,6 +178,8 @@ class DynamoDBConnectorSuite extends AnyFunSuite with Matchers {
     outContent.reset()
     connector.write(data, Some("suffix"))
     assert(outContent.toString.contains("Suffix will be ignored in DynamoDBConnector"))
+
+    connector.drop()
   }
 
 }


### PR DESCRIPTION
- Create traits `CanDrop`, `CanCreate` and `CanDelete`
- `Connector` now inherits the previous three traits
- The `drop` method is implemented in `JDBCConnector` and `CassandraConnector`
- it's not yet implemented in `DynamoDBConnector`
- `Connector` inherits `HasSparkSession`
- The child classes of `Connector` doesn't inherit directly `HasSparkSession`
- The variable `writer` and `reader` of the trait `Connector` are now **protected**