### PR TITLE
feat: update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ New Features:
 - Added default Spark job group and description (#115)
 
 Fixes
+- Fixed path separator in FileConnectorSuite
 
 ## 0.4.2 (2020-02-15)
 - Fixed cross building issue (#111)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
 ## 0.4.3 (2020-03-26)
+Changes:
+- Updated spark-cassandra-connector from 2.4.2 to 2.5.0
+- Updated spark-excel-connector from 0.12.4 to 0.13.1
+- Updated spark-dynamodb-connector from 1.0.1 to 1.0.4
+- Updated scalatest (scope test) from 3.1.0 to 3.1.2
+- Updated postgresql (scope test) from 42.2.9 to 42.2.12
+
 New Features:
 - Added pipeline dependency check before starting the spark job (#113)
 - Added default Spark job group and description (#115)
+
+Fixes
 
 ## 0.4.2 (2020-02-15)
 - Fixed cross building issue (#111)

--- a/pom.xml
+++ b/pom.xml
@@ -125,17 +125,17 @@
         <dependency>
             <groupId>com.datastax.spark</groupId>
             <artifactId>spark-cassandra-connector_${scala.compat.version}</artifactId>
-            <version>2.4.2</version>
+            <version>2.5.0</version>
         </dependency>
         <dependency>
             <groupId>com.crealytics</groupId>
             <artifactId>spark-excel_${scala.compat.version}</artifactId>
-            <version>0.12.4</version>
+            <version>0.13.1</version>
         </dependency>
         <dependency>
             <groupId>com.audienceproject</groupId>
             <artifactId>spark-dynamodb_${scala.compat.version}</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.4</version>
         </dependency>
         <!-- TYPESAFE CONFIG -->
         <dependency>
@@ -147,13 +147,13 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.compat.version}</artifactId>
-            <version>3.1.0</version>
+            <version>3.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.2.9</version>
+            <version>42.2.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/CassandraConnector.scala
@@ -1,8 +1,8 @@
 package com.jcdecaux.setl.storage.connector
 
-import com.datastax.spark.connector.cql.{CassandraConnector => DatastaxCassandraConnector}
-import com.datastax.driver.core.exceptions.AlreadyExistsException
+import com.datastax.oss.driver.api.core.servererrors.AlreadyExistsException
 import com.datastax.spark.connector._
+import com.datastax.spark.connector.cql.{CassandraConnector => DatastaxCassandraConnector}
 import com.jcdecaux.setl.annotation.InterfaceStability
 import com.jcdecaux.setl.config.Conf
 import com.jcdecaux.setl.enums.Storage
@@ -182,7 +182,7 @@ class CassandraConnector(val keyspace: String,
     }
   }
 
-  @throws[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException]("Make sure the strategy is correct")
+  @throws[com.datastax.oss.driver.api.core.servererrors.QueryValidationException]("Make sure the strategy is correct")
   def createKeyspace(strategy: String, replicationFactor: Int): Unit = {
     log.debug(s"Create cassandra keyspace $keyspace")
     cqlConnection.withSessionDo {

--- a/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
+++ b/src/main/scala/com/jcdecaux/setl/storage/connector/ExcelConnector.scala
@@ -3,7 +3,7 @@ package com.jcdecaux.setl.storage.connector
 import com.jcdecaux.setl.annotation.InterfaceStability
 import com.jcdecaux.setl.config.Conf
 import com.jcdecaux.setl.enums.Storage
-import com.jcdecaux.setl.util.{HasSparkSession, TypesafeConfigUtils}
+import com.jcdecaux.setl.util.TypesafeConfigUtils
 import com.typesafe.config.Config
 import org.apache.spark.sql._
 import org.apache.spark.sql.types.StructType
@@ -65,7 +65,7 @@ class ExcelConnector(val path: String,
 
   def this(conf: Conf) = this(
     path = conf.get("path").get,
-    useHeader = conf.get("useHeader").get,
+    useHeader = conf.get("header").getOrElse(conf.get("useHeader").get),
     dataAddress = conf.get("dataAddress").getOrElse("A1"),
     treatEmptyValuesAsNulls = conf.get("treatEmptyValuesAsNulls").getOrElse("true"),
     inferSchema = conf.get("inferSchema").getOrElse("false"),
@@ -88,7 +88,9 @@ class ExcelConnector(val path: String,
     path =
       TypesafeConfigUtils.getAs[String](config, "path").get,
     useHeader =
-      TypesafeConfigUtils.getAs[String](config, "useHeader").get,
+      TypesafeConfigUtils
+        .getAs[String](config, "header")
+        .getOrElse(TypesafeConfigUtils.getAs[String](config, "useHeader").get),
     dataAddress =
       TypesafeConfigUtils.getAs[String](config, "dataAddress").getOrElse("A1"),
     treatEmptyValuesAsNulls =
@@ -141,7 +143,7 @@ class ExcelConnector(val path: String,
     val _writer = df
       .write
       .format("com.crealytics.spark.excel")
-      .option("useHeader", useHeader)
+      .option("header", useHeader)
       .option("dataAddress", dataAddress)
       .option("timestampFormat", timestampFormat)
       .option("dateFormat", dateFormat) // Optional, default: yy-m-d h:mm
@@ -169,7 +171,7 @@ class ExcelConnector(val path: String,
     val reader = spark
       .read
       .format("com.crealytics.spark.excel")
-      .option("useHeader", useHeader)
+      .option("header", useHeader)
       .option("dataAddress", dataAddress)
       .option("treatEmptyValuesAsNulls", treatEmptyValuesAsNulls)
       .option("inferSchema", inferSchema)

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -6,7 +6,7 @@ log4j.additivity.com.jcdecaux=false
 # Decrease the verbosity of external libraries logging
 log4j.logger.org.apache=WARN, stdout
 log4j.additivity.org.apache=false
-log4j.logger.com.datastax=WARN, stdout
+log4j.logger.com.datastax=INFO, stdout
 log4j.additivity.com.datastax=false
 log4j.logger.io.netty=WARN, stdout
 log4j.additivity.io.netty=false

--- a/src/test/scala/com/jcdecaux/setl/MockCassandra.scala
+++ b/src/test/scala/com/jcdecaux/setl/MockCassandra.scala
@@ -1,12 +1,12 @@
 package com.jcdecaux.setl
 
-import com.datastax.driver.core.Session
+import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.spark.connector.cql.CassandraConnector
 import org.apache.spark.SparkConf
 
 class MockCassandra(connector: CassandraConnector, keyspace: String) {
 
-  private def dropTable(table: String, session: Session): Unit = session.execute(s"DROP TABLE IF EXISTS $keyspace.$table;")
+  private def dropTable(table: String, session: CqlSession): Unit = session.execute(s"DROP TABLE IF EXISTS $keyspace.$table;")
 
   def dropKeyspace(): this.type = {
     connector.withSessionDo(session => {
@@ -326,8 +326,6 @@ object MockCassandra {
   val cassandraConf: SparkConf = new SparkConf(true)
     .set("spark.cassandra.connection.host", host)
     .set("spark.cassandra.connection.port", "9042")
-    .set("spark.cassandra.connection.keep_alive_ms", "5000")
-    .set("spark.cassandra.connection.timeout_ms", "30000")
     .set("spark.ui.showConsoleProgress", "false")
     .set("spark.ui.enabled", "false")
     .set("spark.cleaner.ttl", "3600")

--- a/src/test/scala/com/jcdecaux/setl/SparkSessionBuilderSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/SparkSessionBuilderSuite.scala
@@ -64,8 +64,6 @@ class SparkSessionBuilderSuite extends AnyFunSuite with BeforeAndAfterAll with S
 
     val sparkConf = new SparkConf(true)
       .set("spark.cassandra.connection.port", "9042")
-      .set("spark.cassandra.connection.keep_alive_ms", "5000")
-      .set("spark.cassandra.connection.timeout_ms", "30000")
       .set("spark.ui.showConsoleProgress", "false")
       .set("spark.ui.enabled", "false")
       .set("spark.cleaner.ttl", "3600")

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/CassandraConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/CassandraConnectorSuite.scala
@@ -236,12 +236,12 @@ class CassandraConnectorSuite extends AnyFunSuite with BeforeAndAfterAll {
     )
 
     // test create keyspace
-    this.connector.withSessionDo (_.execute("DROP KEYSPACE IF EXISTS test_spark_connector_keyspace"))
-    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](
+    this.connector.withSessionDo(_.execute("DROP KEYSPACE IF EXISTS test_spark_connector_keyspace"))
+    assertThrows[com.datastax.oss.driver.api.core.servererrors.QueryValidationException](
       connector.write(testTable.toDF()),
       "Exception should be thrown because the keyspace doesn't exist"
     )
-    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](
+    assertThrows[com.datastax.oss.driver.api.core.servererrors.QueryValidationException](
       connector.createKeyspace("WrongStrategy", 1),
       "Exception should be thrown when the strategy is wrong"
     )
@@ -254,7 +254,7 @@ class CassandraConnectorSuite extends AnyFunSuite with BeforeAndAfterAll {
     val dropMethod = classOf[CassandraConnector].getDeclaredMethod("dropKeyspace")
     dropMethod.setAccessible(true)
     dropMethod.invoke(connector)
-    assertThrows[com.datastax.driver.core.exceptions.InvalidConfigurationInQueryException](
+    assertThrows[com.datastax.oss.driver.api.core.servererrors.QueryValidationException](
       connector.write(testTable.toDF()),
       "Exception should be thrown because the keyspace was dropped"
     )

--- a/src/test/scala/com/jcdecaux/setl/storage/connector/FileConnectorSuite.scala
+++ b/src/test/scala/com/jcdecaux/setl/storage/connector/FileConnectorSuite.scala
@@ -1,11 +1,9 @@
 package com.jcdecaux.setl.storage.connector
 
-import java.io.File
-
 import com.jcdecaux.setl.config.FileConnectorConf
 import com.jcdecaux.setl.enums.Storage
 import com.jcdecaux.setl.{SparkSessionBuilder, TestObject}
-import org.apache.hadoop.fs.LocalFileSystem
+import org.apache.hadoop.fs.{LocalFileSystem, Path}
 import org.apache.spark.sql.{DataFrame, Dataset, SaveMode, SparkSession}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -330,7 +328,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
     }
 
     assert(connector.listFiles().length >= 6) // >= because some OS will add hidden files (like .DS_Store in MacOS)
-    connector.listFilesToLoad(false).map(_.split(File.separatorChar).last) should contain theSameElementsAs Array(
+    connector.listFilesToLoad(false).map(_.split(Path.SEPARATOR).last) should contain theSameElementsAs Array(
       "file2-1.csv",
       "file1.csv",
       "file1-2-2.csv",


### PR DESCRIPTION
Changes:
- Updated spark-cassandra-connector from 2.4.2 to 2.5.0
- Updated spark-excel-connector from 0.12.4 to 0.13.1
- Updated spark-dynamodb-connector from 1.0.1 to 1.0.4
- Updated scalatest (scope test) from 3.1.0 to 3.1.2
- Updated postgresql (scope test) from 42.2.9 to 42.2.12

-------

There are several breaking changes in these updates:
- the library `spark-excel-connector` has changed the argument name from "useHeader" to "header" (https://github.com/JCDecaux/setl/pull/117/files#diff-6e816bd4fa1c0139464fd24097d69831R146)
- the new version of `spark-cassandra-connector` has changed the underlying Cassandra Java driver. That breaks some exception handling code (https://github.com/JCDecaux/setl/pull/117/files#diff-e1a976d05446be7a5f904df7781df62dR240)
- the new Cassandra connector has also deprecated some configuration, which breaks the test. They have been removed (https://github.com/JCDecaux/setl/pull/117/files)

I also fixed a small issue of file path separator which may cause the test to fail in windows (https://github.com/JCDecaux/setl/pull/117/files#diff-933c0d96e79dcd26e884ae6386f24f2fR331)